### PR TITLE
Serving gravatar over https

### DIFF
--- a/_includes/bio.html
+++ b/_includes/bio.html
@@ -1,6 +1,6 @@
 <section id="bio" class="section bio">
   {% if site.gravatar %}
-    <img class="bio-img" src="http://www.gravatar.com/avatar/{{ site.gravatar }}?s=400" alt="{{ site.author }}"
+    <img class="bio-img" src="https://www.gravatar.com/avatar/{{ site.gravatar }}?s=400" alt="{{ site.author }}"
   {% else %}
     <i class="bio-icon icon-vcard"></i>
   {% endif %}


### PR DESCRIPTION
Gravatar is not being served over https, so Chrome DevTools warns you about it. It's actually a minor security issue, nothing serious.
