### PR TITLE
Adjusted very large font sizes on header

### DIFF
--- a/css/_header.sass
+++ b/css/_header.sass
@@ -4,15 +4,16 @@ header
 
 .header-info
   @include align(both)
+  width: 100%
 
 .author-name
-  font-size: rem(70)
+  font-size: rem(60)
 
 .author-title
   font-size: rem(25)
 
 .feature-icon
-  font-size: rem(80)
+  font-size: rem(70)
   @include transition(all 0.5s ease-in-out)
 
   &:hover


### PR DESCRIPTION
Header fonts were breaking or getting out of the screen in some devices
I tested.

I reduced the font-size and made it inline (just because it is prettier
in my opinion).

See if you like it 😄 
